### PR TITLE
Add seabios to backports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,15 @@ ENV DISTRIBUTION=${distribution}
 
 COPY build_backport.sh /scripts/
 
+##### Backports from Vivid before installing any Utopic packages necessary for libvirt
+COPY vivid-source-packages.list /etc/apt/sources.list.d/
+
+RUN sudo apt-get update && apt-src install seabios
+RUN /scripts/build_backport.sh seabios-1.7.5
+
+RUN sudo rm /etc/apt/sources.list.d/vivid-source-packages.list
+
+
 ##### Backports from Xenial before installing any Utopic packages necessary for libvirt
 COPY xenial-source-packages.list /etc/apt/sources.list.d/
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@ OUTPUT_DIR := $(CURDIR)/output
 
 .PHONY: build clean
 
-build:
-	$(MAKE) clean
+build: clean
 	$(CURDIR)/build.sh
 
 clean:


### PR DESCRIPTION
qemu depends on a slightly newer seabios

The Xenial package didn't build on the first try and it looks like this
isn't a package that really receives security updates thus far so I just
tried the Vivid version that satisfies the dependency

Drive-by: Clean up Makefile a little more