### PR TITLE
Retrieve gcc-4.9 binary packages from ubuntu PPA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,18 @@ ENV QUILT_PATCHES=debian/patches
 
 COPY build_backport.sh /scripts/
 
+# Retrieve binary packages for gcc-4.9 from toolchain test PPA
+RUN sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN sudo apt-get update \
+  && sudo apt-get \
+    -y \
+    --download-only \
+    -o Dir::Cache::Archives="/build/" \
+    install gcc-4.9
+RUN sudo rm /etc/apt/sources.list.d/ubuntu-toolchain-r-test-trusty.list
+RUN sudo rm -rf /build/lock /build/partial
+RUN sudo chown builder:builder /build/*.deb
+
 ##### Forward-port ZFS/SPL 0.7.1 package from PPA to newer ZFS version
 # See https://www.debian.org/doc/manuals/maint-guide/update.en.html#newupstream
 ARG new_zfs_version="0.7.8"


### PR DESCRIPTION
These need to go into our repository so we can build pip packages with
GCC 4.9 (some pip packages use compiler flags that depend on it)